### PR TITLE
Adds key for modifying the homepage of the browser

### DIFF
--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -12,6 +12,9 @@
     "chrome_url_overrides": {
         "newtab": "/newtab/newtab.html"
     },
+    "chrome_settings_overrides": {
+        "homepage": "/newtab/newtab.html"
+    },
     "background": {
         "scripts": ["background.js"]
     },


### PR DESCRIPTION
Added the chrome_settings_overrides key. Under that, the homepage key modifies the homepage of the browser as well. Without this only new tabs will have the Minecraft weather new tab and the page that is shown to the user at start up will still be the default one.